### PR TITLE
cleanup docker warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04 AS builder-ssl
 ARG SSLLIB
 
 # combined list of dependencies for QuicTLS, AWS-LC
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y install git g++ make gcc wget autoconf libtool cmake curl libasan5
 
 # AWS-LC requirement
@@ -31,7 +31,7 @@ COPY --from=builder-ssl \
 
 ADD *.patch /tmp/
 ADD https://api.github.com/repos/haproxy/haproxy/git/refs/heads/quic-interop version.json
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y install git make gcc liblua5.3-0 liblua5.3-dev \
   && git clone --depth 1 -b quic-interop https://github.com/haproxy/haproxy.git haproxy \
   && cd /haproxy \


### PR DESCRIPTION
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 7)
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 34)